### PR TITLE
支持使用HDfury Vertex2 or VRRoom 设备

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -70,7 +70,7 @@ Player:
 TV:
   # 引用的TV执行器
   # 目前有2个，一个sony bravia，一个lg的, 根据你的电视类型选择
-  # 索尼就用tv.sony_bravia.SonyBravia, LG就用tv.lg_webos.LGWebos
+  # 索尼就用tv.sony_bravia.SonyBravia, LG就用tv.lg_webos.LGWebos, HDFURY就用tv.hdfury.Hdfury
   Executor: tv.sony_bravia.SonyBravia
   # 电视IP, 改成你自己的
   IP: 192.168.1.12

--- a/tv/hdfury.py
+++ b/tv/hdfury.py
@@ -1,0 +1,78 @@
+"""
+HDfury Vertex2 or VRRoom hdmi设备
+"""
+import requests
+import logging
+from abstract_classes import TV, TVException
+
+logger = logging.getLogger(__name__)
+
+
+class Hdfury(TV):
+    def __init__(self, config: dict):
+        super().__init__(config)
+        try:
+            self._ip = self._config.get('IP', None)
+            self._hdmi = self._config.get('HDMI', 1)
+            self._play_stop_uri = self._config.get('PlayStopUri', None)
+            self._uri = "http://{}/".format(self._ip)
+        except Exception as e:
+            raise TVException(e)
+
+
+
+    def _change_hdmi(self, hdmi):
+        """
+        修改hdmi输入
+        :return:
+        """
+        try:
+            url = self._uri + "cmd?insel={}%204".format(hdmi)
+            header = {
+                "Accept": "*/*"
+            }
+
+            res = requests.get(url=url, headers=header)
+            if res.status_code == 200:
+                if "OK" == res.text:
+                    return True
+        except Exception as e:
+            logger.error("change hdmi error: {}".format(e))
+        return False
+
+
+
+
+
+    def start_before(self, **kwargs):
+        """
+        初始化执行
+        :param kwargs:
+        :return:
+        """
+        pass
+
+    def play_begin(self, on_message, **kwargs):
+        """
+        播放开始
+        :param on_message:
+        :param kwargs:
+        :return:
+        """
+        self._change_hdmi(self._hdmi)
+
+    def play_end(self, on_message, **kwargs):
+        """
+        播放结束
+        :param on_message:
+        :param kwargs:
+        :return:
+        """
+        # 控制播放结束后操作，只支持不同的hdmi
+        if self._play_stop_uri is not None:
+            results = str.split(self._play_stop_uri, "=")
+            key = results[0]
+            value = results[1]
+            if key.lower() == "hdmi":
+                self._change_hdmi(value)
+


### PR DESCRIPTION
TV增加一个设备类hdfury.py，实现使用HDfury Veterx 或VRRoom设备切换hdmi，VRRoom实测通过。

"""
HDfury Vertex2 or VRRoom hdmi设备
"""
import requests
import logging
from abstract_classes import TV, TVException

logger = logging.getLogger(__name__)


class Hdfury(TV):
    def __init__(self, config: dict):
        super().__init__(config)
        try:
            self._ip = self._config.get('IP', None)
            self._hdmi = self._config.get('HDMI', 1)
            self._play_stop_uri = self._config.get('PlayStopUri', None)
            self._uri = "http://{}/".format(self._ip)
        except Exception as e:
            raise TVException(e)



    def _change_hdmi(self, hdmi):
        """
        修改hdmi输入
        :return:
        """
        try:
            url = self._uri + "cmd?insel={}%204".format(hdmi)
            header = {
                "Accept": "*/*"
            }

            res = requests.get(url=url, headers=header)
            if res.status_code == 200:
                if "OK" == res.text:
                    return True
        except Exception as e:
            logger.error("change hdmi error: {}".format(e))
        return False





    def start_before(self, **kwargs):
        """
        初始化执行
        :param kwargs:
        :return:
        """
        pass

    def play_begin(self, on_message, **kwargs):
        """
        播放开始
        :param on_message:
        :param kwargs:
        :return:
        """
        self._change_hdmi(self._hdmi)

    def play_end(self, on_message, **kwargs):
        """
        播放结束
        :param on_message:
        :param kwargs:
        :return:
        """
        # 控制播放结束后操作，只支持不同的hdmi
        if self._play_stop_uri is not None:
            results = str.split(self._play_stop_uri, "=")
            key = results[0]
            value = results[1]
            if key.lower() == "hdmi":
                self._change_hdmi(value)

